### PR TITLE
Fix a return type of signIn method

### DIFF
--- a/gapi.auth2.d.ts
+++ b/gapi.auth2.d.ts
@@ -34,7 +34,7 @@ declare module gapi.auth2 {
       fetch_basic_profile?: boolean;
       prompt?: boolean;
       scope?: string;
-    }, optionBuilder?: SigninOptionsBuilder): any;
+    }, optionBuilder?: SigninOptionsBuilder): Promise<GoogleUser>;
 
     /**
      * Signs out all accounts from the application.


### PR DESCRIPTION
https://developers.google.com/identity/sign-in/web/reference
According to this document, almost method have promise return value.
I think this way is more useful